### PR TITLE
fix test_run_command_fail

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -23,8 +23,8 @@ fn test_run_command() {
 #[test]
 fn test_run_command_fail() {
   let result = run_command("asldfkjh test");
-  assert_eq!(
+  assert!(matches!(
     result,
-    Err(String::from("bash: asldfkjh: command not found\n"))
-  );
+    Err(e) if e.contains("command not found") && e.contains("asldfkjh"),
+  ));
 }


### PR DESCRIPTION
I ran in to this error when running `cargo test`, not sure if there is a bash update that changed that or the bash on my machine is just different. This pull request should be able to make it more compatible with different versions of bash

```console
---- command::test_run_command_fail stdout ----
thread 'command::test_run_command_fail' panicked at 'assertion failed: `(left == right)`
  left: `Err("bash: line 1: asldfkjh: command not found\n")`,
 right: `Err("bash: asldfkjh: command not found\n")`', src/command.rs:26:3
```

Note that `assert!(matches!())` could be changed to `assert_matches!` once it is stable: https://github.com/rust-lang/rust/issues/82775