### PR TITLE
Implemented a config to make commands close lazycli after executing t…

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -30,6 +30,8 @@ pub struct App<'a> {
   pub focused_panel: FocusedPanel,
   pub selected_item_content: String,
   pub config_path: PathBuf,
+  pub terminate_after_confirmation_popup: bool,     // makes the confirmation popup terminate lazycli if the user confirmed running the command
+  pub terminate_immediatly: bool,     		          // makes lazycli terminate directly
 }
 
 impl<'a> App<'a> {
@@ -48,6 +50,8 @@ impl<'a> App<'a> {
       focused_panel: FocusedPanel::Table,
       selected_item_content: String::from(""),
       config_path,
+      terminate_after_confirmation_popup: false, 
+      terminate_immediatly: false   
     }
   }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -52,6 +52,10 @@ pub struct KeyBinding {
   pub confirm: bool,
   #[serde(skip_serializing_if = "Option::is_none")]
   pub regex: Option<String>,
+  #[serde(default = "bool::default")]
+  #[serde(skip_serializing_if = "IsFalse::is_false")]  
+  pub quit_after_running: bool,
+
 }
 
 impl Default for KeyBinding {
@@ -61,6 +65,7 @@ impl Default for KeyBinding {
       command: String::from(""),
       confirm: false,
       regex: None,
+      quit_after_running: false,
     }
   }
 }


### PR DESCRIPTION
Implemented a config setting to for lazycli to shut down after executing a command.
This is useful for commands the user always want's to close lazycli afterwards, such as enabling a conda environment.

Adding the setting "quit_after_running: true" to any key binding in the config.yaml to enable this behaviour

